### PR TITLE
Update address to MA Backoffice

### DIFF
--- a/ModelicaAssociationCLA.md
+++ b/ModelicaAssociationCLA.md
@@ -35,13 +35,7 @@ individual contributors.
 
 Please complete and sign, then scan and email a pdf file of this
 Agreement to backoffice@modelica.org and send the original signed
-Agreement to:
-
-> MA Backoffice\
-> c/o LTX Simulation GmbH\
-> Wohlfartstr. 21b\
-> 80939 München\
-> Germany
+Agreement to the Modelica Association Backoffice, see https://modelica.org/association.html for the address.
 
 <div style="page-break-after: always;"></div>
 

--- a/ModelicaAssociationCLA.md
+++ b/ModelicaAssociationCLA.md
@@ -34,13 +34,14 @@ contributions as employees of that Corporation only and not as
 individual contributors.
 
 Please complete and sign, then scan and email a pdf file of this
-Agreement to board@modelica.org and send the original signed Agreement
-to:
+Agreement to backoffice@modelica.org and send the original signed
+Agreement to:
 
-> Modelica Association\
-> c/o PELAB, IDA, Linköpings Universitet\
-> S-58183 Linköping\
-> Sweden
+> MA Backoffice\
+> c/o LTX Simulation GmbH\
+> Wohlfartstr. 21b\
+> 80939 München\
+> Germany
 
 <div style="page-break-after: always;"></div>
 


### PR DESCRIPTION
I think the agreement should be sent to the MA Backoffice instead of the seat of the registered MA organization. Please correct me if I am wrong. I also changed the mail address to backoffice@modelica.org.